### PR TITLE
bbox 형식 자유 변환 추가 / 기본 값은 coco형식으로 반환

### DIFF
--- a/dataset/__init__.py
+++ b/dataset/__init__.py
@@ -1,2 +1,2 @@
 from .data_loader import get_dataloaders
-from .pill_dataset import PillDetectionDataset, TestDataset
+from .pill_dataset import PillDetectionDataset, TestDataset, convert_bbox_format

--- a/dataset/data_loader.py
+++ b/dataset/data_loader.py
@@ -4,7 +4,7 @@ from sklearn.model_selection import train_test_split
 from .pill_dataset import PillDetectionDataset
 
 
-def get_dataloaders(csv_path, image_dir, batch_size=8, val_split=0.2, shuffle=True):
+def get_dataloaders(csv_path, image_dir, bbox_convert=False, batch_size=8, val_split=0.2, shuffle=True):
     """
     훈련 데이터와 검증 데이터로 나누어 데이터로더를 생성합니다.
 
@@ -24,8 +24,8 @@ def get_dataloaders(csv_path, image_dir, batch_size=8, val_split=0.2, shuffle=Tr
     train_df, val_df = train_test_split(df, test_size=val_split, random_state=42, shuffle=True)
 
     # 데이터셋 생성
-    train_dataset = PillDetectionDataset(train_df, image_dir, train=True)
-    val_dataset = PillDetectionDataset(val_df, image_dir, train=False)
+    train_dataset = PillDetectionDataset(train_df, image_dir, train=True, bbox_convert=bbox_convert)
+    val_dataset = PillDetectionDataset(val_df, image_dir, train=False, bbox_convert=bbox_convert)
 
     # 데이터로더 생성
     train_loader = DataLoader(

--- a/src/visualization.py
+++ b/src/visualization.py
@@ -1,7 +1,8 @@
 import matplotlib.pyplot as plt
 import cv2
+from dataset import convert_bbox_format
 
-def visualize_sample(image, image_vis, target, class_id=False):
+def visualize_sample(image, image_vis, target, class_id=False, bbox_convert=True):
     """
     바운딩 박스를 시각화하는 함수.
     Args:
@@ -12,6 +13,9 @@ def visualize_sample(image, image_vis, target, class_id=False):
     """
     boxes = target["boxes"].cpu().numpy().astype(int)
     labels = target["labels"].cpu().numpy()
+    
+    if bbox_convert:
+        boxes = convert_bbox_format(boxes)
 
     # 바운딩 박스 그리기
     for i, (box, label) in enumerate(zip(boxes, labels)):


### PR DESCRIPTION
## ⛏ 작업 내용
원래 파스칼 형식으로 반환되던 bbox를 형식을 선택할 수 있도록 변경
파스칼 = (x_min, y_min, x_max, y_max)
coco = (x, y, w, h)
기본값은 coco로 반환됨

사용하는 모델들이 대부분은 coco형식을 기본으로 사용하고
Faster R-CNN만 파스칼을 기본으로 사용함

형식 선택 방법
데이터 로더 불러오는 함수에 bbox_convert 인자로 선택
False = coco
True = pascal voc